### PR TITLE
Allow google maps to be embedded in full_html format.

### DIFF
--- a/modules/bene_core/config/install/filter.format.full_html.yml
+++ b/modules/bene_core/config/install/filter.format.full_html.yml
@@ -44,6 +44,6 @@ filters:
     status: false
     weight: -10
     settings:
-      allowed_html: '<a href hreflang> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <drupal-entity data-* alt title> <s> <sup> <sub> <img src alt data-entity-type data-entity-uuid data-align data-caption> <table> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <hr> <p> <h1> <pre>'
+      allowed_html: '<a href hreflang> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <drupal-entity data-* alt title> <s> <sup> <sub> <img src alt data-entity-type data-entity-uuid data-align data-caption> <table> <caption> <tbody> <thead> <tfoot> <th> <td> <tr> <hr> <p> <h1> <pre> <iframe style src width height frameborder> <allowfullscreen>'
       filter_html_help: true
       filter_html_nofollow: false


### PR DESCRIPTION
I made this change on the live OTFO configuration, and it has also been made on other sites. It's not my favorite thing to just be embedding everything in wysiwygs, but it seems like a common enough use case, especially with google maps. Still, I don't love just saying "fine, iframe whatever you want". What do y'all think? The UX for these also sucks: you have to switch to source mode in the wysiwyg.

Another option is to handle these as custom block types, or even custom media entity types. We could just have a general "embed" block type that lets you paste in an embed code without going into "Source" mode. Would make it a little easier to track and troubleshoot, and leaves at least SOME structure. I think I like that solution best, but haven't given it a ton of thought.

We could even include a drop-down for "type" and use that to filter the tags if we wanted, although that seems like probably overkill. Perhaps we could just use it to add a class of some kind so the css can target different types of iframes more easily.